### PR TITLE
Respect bufferSize in MemoryOutput

### DIFF
--- a/lib/src/outputs/memory_output.dart
+++ b/lib/src/outputs/memory_output.dart
@@ -12,7 +12,7 @@ class MemoryOutput extends LogOutput {
   @override
   void output(OutputEvent event) {
     if (buffer.length == bufferSize) {
-      buffer.take(1);
+      buffer.removeFirst();
     }
 
     buffer.add(event);

--- a/test/memory_output_test.dart
+++ b/test/memory_output_test.dart
@@ -1,0 +1,19 @@
+import 'package:logger/logger.dart';
+import 'package:test/test.dart';
+
+main() {
+  test('Memory output buffer size is limited', () {
+    MemoryOutput output = MemoryOutput(bufferSize: 2);
+
+    final event0 = OutputEvent(Level.info, []);
+    final event1 = OutputEvent(Level.info, []);
+    final event2 = OutputEvent(Level.info, []);
+
+    output.output(event0);
+    output.output(event1);
+    output.output(event2);
+
+    expect(output.buffer.length, 2);
+    expect(output.buffer, containsAllInOrder([event1, event2]));
+  });
+}


### PR DESCRIPTION
`buffer.take(1)` returns new list. But original buffer is left unchanged.