### PR TITLE
Add time when told to

### DIFF
--- a/lib/src/printers/simple_printer.dart
+++ b/lib/src/printers/simple_printer.dart
@@ -22,7 +22,8 @@ class SimplePrinter extends LogPrinter {
   void log(LogEvent event) {
     var messageStr = stringifyMessage(event.message);
     var errorStr = event.error != null ? "  ERROR: ${event.error}" : "";
-    println("${levelPrefixes[event.level]}  $messageStr$errorStr");
+    var timeStr = printTime ? "TIME: ${DateTime.now().toIso8601String()}" : "";
+    println("${levelPrefixes[event.level]} $timeStr $messageStr$errorStr");
   }
 
   String stringifyMessage(dynamic message) {


### PR DESCRIPTION
Closes #12.

I wish there was a way to test the output of the printer but there's no way to get to the `_buffer` field of the `LogPrinter`. 
Won't it be easier to have the `log` call just return a `List<String>`? In the `logger.dart` file [line 110](https://github.com/leisim/logger/blob/master/lib/src/logger.dart#L110) you could just deal with the `List<String>` there. This makes the mandatory `println` obsolete in favour of just a requirement to implement a method signature (`List<String> log(LogEvent event)`).