### PR TITLE
Explicitly set the variable to null

### DIFF
--- a/test/logger_test.dart
+++ b/test/logger_test.dart
@@ -39,6 +39,13 @@ void main() {
     printedStackTrace = s;
   });
 
+  setUp(() {
+    printedLevel = null;
+    printedMessage = null;
+    printedError = null;
+    printedStackTrace = null;
+  });
+
   test('Logger.log', () {
     Logger logger = Logger(filter: _NeverFilter(), printer: callbackPrinter);
     logger.log(Level.debug, "Some message");


### PR DESCRIPTION
These variables are set during the tests. But the value a variable is set to
carries over to the next test. This doesn't lead to problems in the current set
of tests but making the starting conditions of each test crystal clear leads to
less surprises.