### PR TITLE
Add logger specific log level

### DIFF
--- a/lib/src/filters/debug_filter.dart
+++ b/lib/src/filters/debug_filter.dart
@@ -9,7 +9,7 @@ class DebugFilter extends LogFilter {
   bool shouldLog(LogEvent event) {
     var shouldLog = false;
     assert(() {
-      if (event.level.index >= Logger.level.index) {
+      if (event.level.index >= level.index) {
         shouldLog = true;
       }
       return true;

--- a/lib/src/filters/production_filter.dart
+++ b/lib/src/filters/production_filter.dart
@@ -4,6 +4,6 @@ part of logger;
 class ProductionFilter extends LogFilter {
   @override
   bool shouldLog(LogEvent event) {
-    return event.level.index >= Logger.level.index;
+    return event.level.index >= level.index;
   }
 }

--- a/lib/src/log_filter.dart
+++ b/lib/src/log_filter.dart
@@ -5,6 +5,7 @@ part of logger;
 /// You can implement your own `LogFilter` or use [DebugFilter].
 /// Every implementation should consider [Logger.level].
 abstract class LogFilter {
+  Level level;
   void init() {}
 
   /// Is called every time a new log message is sent and decides if

--- a/lib/src/logger.dart
+++ b/lib/src/logger.dart
@@ -52,11 +52,16 @@ class Logger {
   /// You can provide a custom [printer], [filter] and [output]. Otherwise the
   /// defaults: [PrettyPrinter], [DebugFilter] and [ConsoleOutput] will be
   /// used.
-  Logger({LogFilter filter, LogPrinter printer, LogOutput output})
-      : _filter = filter ?? DebugFilter(),
+  Logger({
+    LogFilter filter,
+    LogPrinter printer,
+    LogOutput output,
+    Level level,
+  })  : _filter = filter ?? DebugFilter(),
         _printer = printer ?? PrettyPrinter(),
         _output = output ?? ConsoleOutput() {
     _filter.init();
+    _filter.level = level ?? Logger.level;
     _printer._buffer = _outputBuffer;
     _printer.init();
     _output.init();

--- a/test/logger_test.dart
+++ b/test/logger_test.dart
@@ -143,4 +143,19 @@ void main() {
     expect(printedError, "Error");
     expect(printedStackTrace, stackTrace);
   });
+
+  test('setting log level above log level of message', () {
+    printedMessage = null;
+    var logger = Logger(
+      filter: ProductionFilter(),
+      printer: callbackPrinter,
+      level: Level.warning,
+    );
+
+    logger.d("This isn't logged");
+    expect(printedMessage, isNull);
+
+    logger.w("This is");
+    expect(printedMessage, "This is");
+  });
 }


### PR DESCRIPTION
Previously all logger instances shared the same log level. This commit adds the
ability to specify log level per instance. It also removes the dependence of a
global variable.