### PR TITLE
Make simple_printer.dart export optional

### DIFF
--- a/example/main.dart
+++ b/example/main.dart
@@ -1,4 +1,5 @@
 import 'package:logger/logger.dart';
+import 'package:logger/src/printers/simple_printer.dart';
 
 var logger = Logger(
   printer: PrettyPrinter(),

--- a/lib/logger.dart
+++ b/lib/logger.dart
@@ -9,11 +9,13 @@ export 'src/outputs/console_output.dart';
 export 'src/outputs/stream_output.dart';
 export 'src/outputs/memory_output.dart';
 export 'src/printers/pretty_printer.dart';
-export 'src/printers/simple_printer.dart';
 export 'src/printers/logfmt_printer.dart';
 
 export 'src/log_output.dart'
     if (dart.library.io) 'src/outputs/file_output.dart';
+
+export 'src/log_printer.dart'
+    if (dart.library.io) 'src/printers/simple_printer.dart';
 
 export 'src/log_filter.dart';
 export 'src/log_output.dart';

--- a/test/printers/simple_printer_test.dart
+++ b/test/printers/simple_printer_test.dart
@@ -1,3 +1,4 @@
+import 'package:logger/src/printers/simple_printer.dart';
 import 'package:test/test.dart';
 import 'package:logger/logger.dart';
 


### PR DESCRIPTION
Hi! Importing dart:io as a dependency makes the package incompatible with browser projects.

One solution can be making simple_printer.dart export optional like file_output.dart

See: https://github.com/leisim/logger/commit/9d6461154d6df042ef09b71f7f9beb97a8aa347a#diff-9efc0241babc652e668a9441d2926a03R2