### PR TITLE
Hybrid and Prefix Printer

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ var logger = Logger(
     printEmojis: true, // Print an emoji for each log message
     printTime: false // Should each log print contain a timestamp
   ),
-)
+);
 ```
 
 ### Auto detecting
@@ -138,6 +138,17 @@ If you created a cool `LogPrinter` which might be helpful to others, feel free t
 Please note that all IDEs (VSCode, XCode, Android Studio, IntelliJ) do not 
 support ANSI escape sequences in their terminal outputs. These escape sequences 
 are used to color output. If using such an IDE do not configure colored output.
+
+However, if you are using a JetBrains IDE (Android Studio, IntelliJ, etc.) 
+you can make use of the [Grep Console Plugin](https://plugins.jetbrains.com/plugin/7125-grep-console)
+and the [`PrefixPrinter`](/lib/src/printers/prefix_printer.dart) 
+decorator to achieved colored logs for any logger:
+
+```dart
+var logger = Logger(
+  printer: PrefixPrinter(PrettyPrinter(colors: false))
+);
+```
 
 ## LogOutput
 

--- a/lib/logger.dart
+++ b/lib/logger.dart
@@ -13,6 +13,8 @@ export 'src/outputs/memory_output.dart';
 export 'src/printers/pretty_printer.dart';
 export 'src/printers/logfmt_printer.dart';
 export 'src/printers/simple_printer.dart';
+export 'src/printers/hybrid_printer.dart';
+export 'src/printers/prefix_printer.dart';
 
 export 'src/log_output.dart'
     if (dart.library.io) 'src/outputs/file_output.dart';

--- a/lib/src/printers/hybrid_printer.dart
+++ b/lib/src/printers/hybrid_printer.dart
@@ -1,0 +1,34 @@
+import 'package:logger/logger.dart';
+import 'package:logger/src/logger.dart';
+import 'package:logger/src/log_printer.dart';
+
+/// A decorator for a [LogPrinter] that allows for the composition of
+/// different printers to handle different log messages. Provide it's
+/// constructor with a base printer, but include named parameters for
+/// any levels that have a different printer:
+///
+/// ```
+/// HybridPrinter(PrettyPrinter(), debug: SimplePrinter());
+/// ```
+///
+/// Will use the pretty printer for all logs except Level.debug
+/// logs, which will use SimplePrinter().
+class HybridPrinter extends LogPrinter {
+  final LogPrinter _realPrinter;
+  var _printerMap;
+
+  HybridPrinter(this._realPrinter,
+      {debug, verbose, wtf, info, warning, error}) {
+    _printerMap = {
+      Level.debug: debug ?? _realPrinter,
+      Level.verbose: verbose ?? _realPrinter,
+      Level.wtf: wtf ?? _realPrinter,
+      Level.info: info ?? _realPrinter,
+      Level.warning: warning ?? _realPrinter,
+      Level.error: error ?? _realPrinter,
+    };
+  }
+
+  @override
+  List<String> log(LogEvent event) => _printerMap[event.level].log(event);
+}

--- a/lib/src/printers/prefix_printer.dart
+++ b/lib/src/printers/prefix_printer.dart
@@ -1,0 +1,43 @@
+import 'package:logger/src/logger.dart';
+import 'package:logger/src/log_printer.dart';
+
+/// A decorator for a [LogPrinter] that allows for the prepending of every
+/// line in the log output with a string for the level of that log. For
+/// example:
+///
+/// ```
+/// PrefixPrinter(PrettyPrinter());
+/// ```
+///
+/// Would prepend "DEBUG" to every line in a debug log. You can supply
+/// parameters for a custom message for a specific log level.
+class PrefixPrinter extends LogPrinter {
+  final LogPrinter _realPrinter;
+  Map<Level, String> _prefixMap;
+
+  PrefixPrinter(this._realPrinter,
+      {debug, verbose, wtf, info, warning, error}) {
+    _prefixMap = {
+      Level.debug: debug ?? 'DEBUG',
+      Level.verbose: verbose ?? 'VERBOSE',
+      Level.wtf: wtf ?? 'WTF',
+      Level.info: info ?? 'INFO',
+      Level.warning: warning ?? 'WARNING',
+      Level.error: error ?? 'ERROR',
+    };
+
+    var len = _longestPrefixLength();
+    _prefixMap.forEach((k, v) => _prefixMap[k] = '${v.padLeft(len)} ');
+  }
+
+  @override
+  List<String> log(LogEvent event) {
+    var realLogs = _realPrinter.log(event);
+    return realLogs.map((s) => '${_prefixMap[event.level]}$s').toList();
+  }
+
+  int _longestPrefixLength() {
+    var compFunc = (String a, String b) => a.length > b.length ? a : b;
+    return _prefixMap.values.reduce(compFunc).length;
+  }
+}

--- a/test/printers/hybrid_printer_test.dart
+++ b/test/printers/hybrid_printer_test.dart
@@ -1,0 +1,42 @@
+import 'package:test/test.dart';
+
+import 'package:logger/src/printers/hybrid_printer.dart';
+import 'package:logger/logger.dart';
+
+final realPrinter = SimplePrinter();
+
+class TestLogPrinter extends LogPrinter {
+  LogEvent latestEvent;
+  @override
+  List<String> log(LogEvent event) {
+    latestEvent = event;
+    return realPrinter.log(event);
+  }
+}
+
+void main() {
+  var printerA = TestLogPrinter();
+  var printerB = TestLogPrinter();
+  var printerC = TestLogPrinter();
+
+  var debugEvent = LogEvent(Level.debug, 'debug', 'blah', StackTrace.current);
+  var infoEvent = LogEvent(Level.info, 'info', 'blah', StackTrace.current);
+  var warningEvent =
+      LogEvent(Level.warning, 'warning', 'blah', StackTrace.current);
+  var errorEvent = LogEvent(Level.error, 'error', 'blah', StackTrace.current);
+
+  var hybridPrinter = HybridPrinter(printerA, debug: printerB, error: printerC);
+  test('uses wrapped printer by default', () {
+    hybridPrinter.log(infoEvent);
+    expect(printerA.latestEvent, equals(infoEvent));
+  });
+
+  test('forwards logs to correct logger', () {
+    hybridPrinter.log(debugEvent);
+    hybridPrinter.log(errorEvent);
+    hybridPrinter.log(warningEvent);
+    expect(printerA.latestEvent, equals(warningEvent));
+    expect(printerB.latestEvent, equals(debugEvent));
+    expect(printerC.latestEvent, equals(errorEvent));
+  });
+}

--- a/test/printers/prefix_printer_test.dart
+++ b/test/printers/prefix_printer_test.dart
@@ -1,0 +1,56 @@
+import 'package:logger/src/printers/prefix_printer.dart';
+import 'package:test/test.dart';
+
+import 'package:logger/logger.dart';
+
+void main() {
+  var debugEvent = LogEvent(Level.debug, 'debug', 'blah', StackTrace.current);
+  var infoEvent = LogEvent(Level.info, 'info', 'blah', StackTrace.current);
+  var warningEvent =
+      LogEvent(Level.warning, 'warning', 'blah', StackTrace.current);
+  var errorEvent = LogEvent(Level.error, 'debug', 'blah', StackTrace.current);
+  var verboseEvent =
+      LogEvent(Level.verbose, 'debug', 'blah', StackTrace.current);
+  var wtfEvent = LogEvent(Level.wtf, 'debug', 'blah', StackTrace.current);
+
+  var allEvents = [
+    debugEvent,
+    warningEvent,
+    errorEvent,
+    verboseEvent,
+    wtfEvent
+  ];
+
+  test('prefixes logs', () {
+    var printer = PrefixPrinter(PrettyPrinter());
+    var actualLog = printer.log(infoEvent);
+    actualLog.forEach((logString) {
+      expect(logString, contains('INFO'));
+    });
+
+    var debugLog = printer.log(debugEvent);
+    debugLog.forEach((logString) {
+      expect(logString, contains('DEBUG'));
+    });
+  });
+
+  test('can supply own prefixes', () {
+    var printer = PrefixPrinter(PrettyPrinter(), debug: 'BLAH');
+    var actualLog = printer.log(debugEvent);
+    actualLog.forEach((logString) {
+      expect(logString, contains('BLAH'));
+    });
+  });
+
+  test('pads to same length', () {
+    const longPrefix = 'EXTRALONGPREFIX';
+    const len = longPrefix.length;
+    var printer = PrefixPrinter(SimplePrinter(), debug: longPrefix);
+    for (var event in allEvents) {
+      var l1 = printer.log(event);
+      l1.forEach((logString) {
+        expect(logString.substring(0, len), isNot(contains('[')));
+      });
+    }
+  });
+}


### PR DESCRIPTION
Hi - new to Flutter/Dart but this has been a helpful package. This pull request would add two `LogPrinter` decorators.

1) `PrefixPrinter`  in prefix_printer.dart
This allows you to wrap any logger with a prefix to all of it's logs. Inspiration for this being #2 and the AndroidStudio grep-console plugin. But this could also be used just in general to decorate any logger:

```dart
final logger = Logger(
  printer:  PrefixPrinter(PrettyPrinter())
);
```
for example would add prefixes (`"DEBUG"`, `"INFO"`, etc.) to each line in the `PrettyPrinter` output. But since it is a decorator you could use the same thing for any other printer.

It also has optional params for each log level to specify the prefix:
```dart
PrefixPrinter(SimplePrinter(), debug: "DBUG", error: "OOPS");
```

Light unit tests in prefix_printer_test.dart

---

2) `HybridPrinter` in hybrid_printer.dart
This allows you to use a different printer for specific log levels. Inspiration for this is that I found with my logs if they were debug logs, I just wanted a simple one-line view of the log, and with regular logs the full `PrettyPrinter` log. With the `HybridPrinter` you can accomplish that like:

```dart
final logger = Logger(
  printer:  HybridPrinter(PrettyPrinter(), debug: SimplePrinter()),
  level: config.logLevel
);
```

Same thing as above where there are parameters for each level. 

Light unit tests in hybrid_printer_test.dart

---

So, just for fun, using them together (how I currently am):

```dart
final logger = Logger(
  printer:  PrefixPrinter(
      HybridPrinter(
          PrettyPrinter(
            methodCount: 2,
            colors: false,
            printTime: true
          ),
        debug: SimplePrinter()
      )),//OneLinePrinter(),
  level: config.logLevel
);
```

![image](https://user-images.githubusercontent.com/25716930/81469673-584fff80-91b4-11ea-83f5-a33f05573acf.png)

The workaround for #2 thus becomes turning colors off, and using prefixes you want for the grep console plugin. Not a full fix, but works nicely for me!

---

Thought I'd submit this MR in hopes you wanted to add it to the project (also wasn't sure to submit it to master or another branch). Project is awesome! I think these could help with more flexibility in people's own loggers. In general, I would be happy to contribute.

Cheers,

Tim