### PR TITLE
MultiOutput class - override init

### DIFF
--- a/lib/src/outputs/multi_output.dart
+++ b/lib/src/outputs/multi_output.dart
@@ -18,6 +18,11 @@ class MultiOutput extends LogOutput {
   }
 
   @override
+  void init() {
+    _outputs.forEach((o) => o.init());
+  }
+
+  @override
   void output(OutputEvent event) {
     _outputs.forEach((o) => o.output(event));
   }

--- a/lib/src/outputs/multi_output.dart
+++ b/lib/src/outputs/multi_output.dart
@@ -26,4 +26,9 @@ class MultiOutput extends LogOutput {
   void output(OutputEvent event) {
     _outputs.forEach((o) => o.output(event));
   }
+
+  @override
+  void destroy() {
+    _outputs.forEach((o) => o.destroy());
+  }
 }


### PR DESCRIPTION
- Add missing override for init() method in MultiOutput class

This override is needed especially if passed FileOutput instance to the instance of MultiOutput