### PR TITLE
use correct name for conditional import

### DIFF
--- a/lib/logger.dart
+++ b/lib/logger.dart
@@ -17,7 +17,8 @@ export 'src/printers/simple_printer.dart';
 export 'src/printers/hybrid_printer.dart';
 export 'src/printers/prefix_printer.dart';
 
-export 'src/log_output.dart' if (dart.io) 'src/outputs/file_output.dart';
+export 'src/log_output.dart'
+    if (dart.library.io) 'src/outputs/file_output.dart';
 
 export 'src/log_filter.dart';
 export 'src/log_output.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,8 +4,8 @@ version: 0.9.4
 homepage: https://github.com/leisim/logger
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
+  sdk: '>=2.8.1 <3.0.0'
 
 dev_dependencies:
-  test: ^1.16.0-nullsafety.10
-  pedantic: ^1.10.0-nullsafety.3
+  test: ^1.15.4
+  pedantic: ^1.9.0


### PR DESCRIPTION
Hi there!

We are using logger in a Flutter app, and now want to reuse it for an AngularDart one,
unfortunately, the conditional import has the wrong name (dart.io should be dart.library.io)
-> using the webdev compiler throws an exception.

This PR changes that