### PR TITLE
use correct name for conditional import

### DIFF
--- a/lib/logger.dart
+++ b/lib/logger.dart
@@ -17,7 +17,8 @@ export 'src/printers/simple_printer.dart';
 export 'src/printers/hybrid_printer.dart';
 export 'src/printers/prefix_printer.dart';
 
-export 'src/log_output.dart' if (dart.io) 'src/outputs/file_output.dart';
+export 'src/log_output.dart'
+    if (dart.library.io) 'src/outputs/file_output.dart';
 
 export 'src/log_filter.dart';
 export 'src/log_output.dart';


### PR DESCRIPTION
Sorry had to re-open,

so same story as in the closed one:
this PR uses the correct import name 'dart.library.io'

Thanks for the great lib!