### PR TITLE
feat: Expose message, error, and stackTrace in OutputEvent

### DIFF
--- a/lib/src/logger.dart
+++ b/lib/src/logger.dart
@@ -29,8 +29,17 @@ class LogEvent {
 class OutputEvent {
   final Level level;
   final List<String> lines;
+  final dynamic message;
+  final dynamic error;
+  final StackTrace? stackTrace;
 
-  OutputEvent(this.level, this.lines);
+  OutputEvent({
+    required this.level,
+    required this.lines,
+    this.message,
+    this.error,
+    this.stackTrace,
+  });
 }
 
 @Deprecated('Use a custom LogFilter instead')
@@ -115,7 +124,13 @@ class Logger {
       var output = _printer.log(logEvent);
 
       if (output.isNotEmpty) {
-        var outputEvent = OutputEvent(level, output);
+        var outputEvent = OutputEvent(
+            level: level,
+            lines: output,
+            message: message,
+            error: error,
+            stackTrace: stackTrace,
+        );
         // Issues with log output should NOT influence
         // the main software behavior.
         try {

--- a/test/outputs/memory_output_test.dart
+++ b/test/outputs/memory_output_test.dart
@@ -5,9 +5,9 @@ void main() {
   test('Memory output buffer size is limited', () {
     var output = MemoryOutput(bufferSize: 2);
 
-    final event0 = OutputEvent(Level.info, []);
-    final event1 = OutputEvent(Level.info, []);
-    final event2 = OutputEvent(Level.info, []);
+    final event0 = OutputEvent(level: Level.info, lines: []);
+    final event1 = OutputEvent(level: Level.info, lines: []);
+    final event2 = OutputEvent(level: Level.info, lines: []);
 
     output.output(event0);
     output.output(event1);

--- a/test/outputs/multi_output_test.dart
+++ b/test/outputs/multi_output_test.dart
@@ -8,7 +8,7 @@ void main() {
 
     final multiOutput = MultiOutput([output1, output2]);
 
-    final event0 = OutputEvent(Level.info, []);
+    final event0 = OutputEvent(level: Level.info, lines: []);
     multiOutput.output(event0);
 
     expect(output1.buffer.length, 1);
@@ -16,7 +16,7 @@ void main() {
     expect(output1.buffer.elementAt(0), equals(output2.buffer.elementAt(0)));
     expect(output1.buffer.elementAt(0), equals(event0));
 
-    final event1 = OutputEvent(Level.info, []);
+    final event1 = OutputEvent(level: Level.info, lines: []);
     multiOutput.output(event1);
 
     expect(output1.buffer.length, 2);
@@ -29,11 +29,11 @@ void main() {
 
   test('passing null does not throw an exception', () {
     final output = MultiOutput(null);
-    output.output(OutputEvent(Level.info, []));
+    output.output(OutputEvent(level: Level.info, lines: []));
   });
 
   test('passing null in the list does not throw an exception', () {
     final output = MultiOutput([null]);
-    output.output(OutputEvent(Level.info, []));
+    output.output(OutputEvent(level: Level.info, lines: []));
   });
 }

--- a/test/outputs/stream_output_test.dart
+++ b/test/outputs/stream_output_test.dart
@@ -9,19 +9,19 @@ void main() {
       expect(e, ['hi there']);
     });
 
-    out.output(OutputEvent(Level.debug, ['hi there']));
+    out.output(OutputEvent(level: Level.debug, lines: ['hi there']));
   });
 
   test('respects listen', () {
     var out = StreamOutput();
 
-    out.output(OutputEvent(Level.debug, ['dropped']));
+    out.output(OutputEvent(level: Level.debug, lines: ['dropped']));
 
     out.stream.listen((var e) {
       expect(e, ['hi there']);
     });
 
-    out.output(OutputEvent(Level.debug, ['hi there']));
+    out.output(OutputEvent(level: Level.debug, lines: ['hi there']));
   });
 
   test('respects pause', () {
@@ -32,8 +32,8 @@ void main() {
     });
 
     sub.pause();
-    out.output(OutputEvent(Level.debug, ['dropped']));
+    out.output(OutputEvent(level: Level.debug, lines: ['dropped']));
     sub.resume();
-    out.output(OutputEvent(Level.debug, ['hi there']));
+    out.output(OutputEvent(level: Level.debug, lines: ['hi there']));
   });
 }


### PR DESCRIPTION
This PR lays the groundwork for adding a FirebaseOutput (see below snippet), which I will be uploading as a separate package on pub.dev due to its dependency on Firebase Crashlytics. To be useful, Firebase needs the message, error, and stack trace, so this PR adds those to the OutputEvent. Once this is merged and released in logger, I'll know what version to use as the minimum version for the logger dependency in the FirebaseOutput package.

```dart
class FirebaseOutput extends LogOutput {
  List<Level> levels;

  FirebaseOutput({
    this.levels = const [Level.error],
  });

  @override
  void output(OutputEvent event) {
    if (levels.contains(event.level)) {
      FirebaseCrashlytics.instance.recordError(
          event.error,
          event.stackTrace,
          reason: event.message);
    }
  }

}
```