### PR TITLE
updated pretty printer stack trace to use error

### DIFF
--- a/lib/src/printers/pretty_printer.dart
+++ b/lib/src/printers/pretty_printer.dart
@@ -129,7 +129,7 @@ class PrettyPrinter extends LogPrinter {
         stackTraceStr = formatStackTrace(StackTrace.current, methodCount);
       }
     } else if (errorMethodCount > 0) {
-      stackTraceStr = formatStackTrace(event.stackTrace, errorMethodCount);
+      stackTraceStr = formatStackTrace(event.stackTrace, event.error == null ? methodCount : errorMethodCount);
     }
 
     var errorStr = event.error?.toString();


### PR DESCRIPTION
## Pretty Printer: 

When passing a stack trace to Log.d it obeys the errorMethodCount instead of the methodCount when cutting the size of the stack trace.

This is not ideal because I might just want to pass in an arbitrary stack trace without making it error.

## Solution: 

Make the stack trace sliced via either the methodCount or errorMethodCount depending on whether the error is defined (not null)

