### PR TITLE
Added logger functionality to print caller, ignore certain callers, and filter printed logs by caller type

### DIFF
--- a/example/caller_logger/main.dart
+++ b/example/caller_logger/main.dart
@@ -1,0 +1,98 @@
+import 'dart:convert';
+
+import 'package:logger/logger.dart';
+import 'package:logger/src/filters/type_filter.dart';
+import 'package:logger/src/loggers/caller_logger.dart';
+
+var logger = CallerLogger(
+  ignoreCallers: {
+    'syncTryCatchHandler',
+  },
+  filter: TypeFilter(
+    ignoreTypes: {
+      IgnoredClass,
+    },
+    ignoreLevel: Level.warning,
+  ),
+  level: Level.verbose,
+);
+
+void main() {
+  print(
+      'Run with either `dart example/caller_logger/main.dart` or `dart --enable-asserts example/caller_logger/main.dart`.');
+  demo();
+}
+
+void demo() {
+  /// Settings are such that:
+  ///
+  /// 1. All logs in ExampleClass are printed (because level: Level.verbose)
+  /// 2. Logs in IgnoredClass are not printed (because ignoreTypes: IgnoredClass),
+  /// except for logs at level of warning and above (because ignoreLevel: Level.warning)
+
+  ExampleClass.run();
+  print('========================================');
+  IgnoredClass.run();
+  print('========================================');
+
+  /// 3. Printed log for this will show ExampleClass.nestedRun() instead of
+  /// syncTryCatchHandler (because ignoreCallers: {'syncTryCatchHandler'})
+  ExampleClass.nestedRun();
+}
+
+class ExampleClass {
+  static void run() {
+    logger.log(Level.verbose, 'log: verbose');
+
+    logger.v('verbose');
+    logger.d('debug');
+    logger.i('info');
+    logger.w('warning');
+    logger.e('error');
+    logger.wtf('wtf');
+  }
+
+  static void nestedRun() {
+    // nested functions will print
+    syncTryCatchHandler(
+      tryFunction: () => jsonDecode('thisIsNotJson'),
+    );
+  }
+}
+
+class IgnoredClass {
+  static void run() {
+    logger.v('verbose');
+    logger.d('debug');
+    logger.i('info');
+    logger.w('warning');
+    logger.e('error');
+    logger.wtf('wtf');
+  }
+}
+
+/// Synchronous try and catch handler to reduce boilerplate
+///
+/// Used as an example to show how nested functions can be ignored in [ignoreCallers]
+dynamic syncTryCatchHandler(
+    {dynamic Function()? tryFunction,
+    Map<Exception, dynamic Function()?>? catchKnownExceptions,
+    dynamic Function()? catchUnknownExceptions}) {
+  try {
+    try {
+      return tryFunction?.call();
+    } on Exception catch (e, s) {
+      if (catchKnownExceptions == null) {
+        rethrow;
+      } else if (catchKnownExceptions.containsKey(e)) {
+        logger.w('handling known exception', e, s);
+        catchKnownExceptions[e]?.call();
+      } else {
+        rethrow;
+      }
+    }
+  } catch (e, s) {
+    logger.e('catchUnknown', e, s);
+    catchUnknownExceptions?.call();
+  }
+}

--- a/lib/src/filters/type_filter.dart
+++ b/lib/src/filters/type_filter.dart
@@ -1,0 +1,40 @@
+import 'package:logger/logger.dart';
+
+/// Creates a filter which allows logs to be selectively ignored based on the
+/// caller Type so that you can compartmentalise printed logs. To be used in
+/// conjunction with a Logger.
+///
+/// E.g., if ExampleClass1.method() and ExampleClass2.method() calls
+/// logger.d('some debug message');
+/// and you are working in Level.debug, but only need the logs for ExampleClass1,
+/// then you can initialise [ignoreTypes] with {ExampleClass2}, and logs from
+/// ExampleClass 2 will not be shown.
+class TypeFilter extends DevelopmentFilter {
+  TypeFilter({required this.ignoreTypes, required this.ignoreLevel});
+
+  /// Sets the caller types where logs should not be printed below a certain ignoreLevel
+  final Set<Type> ignoreTypes;
+
+  /// Sets the level above which logs for callers in ignoreTypes are not printed.
+  ///
+  /// This allows you to always print higher level logs, e.g., warnings and above, even
+  /// if it is in ignoreTypes
+  final Level ignoreLevel;
+
+  @override
+  bool shouldLog(LogEvent event) {
+    // Ignore printing of callers of types included in ignoreClass so that you
+    //
+    if (ignoreTypes.any(
+        (element) => event.message.toString().contains(element.toString()))) {
+      // Always print if event level is above ignoreLevel
+      if (event.level.index >= ignoreLevel.index) {
+        return true;
+      } else {
+        return false;
+      }
+    }
+    // If not in a caller type which should be ignored, use default handling
+    return super.shouldLog(event);
+  }
+}

--- a/lib/src/loggers/caller_logger.dart
+++ b/lib/src/loggers/caller_logger.dart
@@ -1,0 +1,66 @@
+import 'package:logger/logger.dart';
+
+/// Custom Logger which prints the caller of the Logger.log() method.
+///
+/// E.g., if ExampleClass1.method() calls logger.d('some debug message'),
+/// then the console will show: ExampleClass1.method: some debug message
+///
+/// [ignoreCallers] can be specified to show the most relevant caller
+class CallerLogger extends Logger {
+  CallerLogger._({
+    LogFilter? filter,
+    LogPrinter? printer,
+    LogOutput? output,
+    Level? level,
+    required Set<String> ignoreCallers,
+  })  : _ignoreCallers = ignoreCallers,
+        super(filter: filter, printer: printer, output: output, level: level);
+
+  factory CallerLogger({
+    LogFilter? filter,
+    LogPrinter? printer,
+    LogOutput? output,
+    Level? level,
+    Set<String>? ignoreCallers,
+  }) {
+    /// Skip callers in stack trace so that the more relevant caller is printed,
+    /// e.g., methods from the loggers or utility functions
+    final _defaultIgnoreCallers = {
+      'CallerLogger.log',
+      'Logger.',
+    };
+    if (ignoreCallers == null) {
+      ignoreCallers = _defaultIgnoreCallers;
+    } else {
+      ignoreCallers.addAll(_defaultIgnoreCallers);
+    }
+    print(ignoreCallers);
+    return CallerLogger._(
+      filter: filter,
+      printer: printer,
+      output: output,
+      level: level,
+      ignoreCallers: ignoreCallers,
+    );
+  }
+
+  Set<String> _ignoreCallers;
+
+  @override
+  void log(Level level, message, [error, StackTrace? stackTrace]) {
+    // get caller
+    final lines = StackTrace.current.toString().split('\n');
+    var caller = 'CallerNotFound';
+    for (var line in lines) {
+      if (_ignoreCallers.any((element) => line.contains(element))) {
+        continue;
+      } else {
+        // ! caller in StackTrace #x seems to be i=6 when split by spaces
+        // ! this may bug out if formatting of StackTrace changes
+        caller = line.split(' ')[6].trim();
+        break; // exit loop to save first caller which is not from the logger
+      }
+    }
+    super.log(level, caller + ': ' + message, error, stackTrace);
+  }
+}


### PR DESCRIPTION
```
import 'dart:convert';

import 'package:logger/logger.dart';
import 'package:logger/src/filters/type_filter.dart';
import 'package:logger/src/loggers/caller_logger.dart';

var logger = CallerLogger(
  ignoreCallers: {
    'syncTryCatchHandler',
  },
  filter: TypeFilter(
    ignoreTypes: {
      IgnoredClass,
    },
    ignoreLevel: Level.warning,
  ),
  level: Level.verbose,
);

void main() {
  print(
      'Run with either `dart example/caller_logger/main.dart` or `dart --enable-asserts example/caller_logger/main.dart`.');
  demo();
}

void demo() {
  /// Settings are such that:
  ///
  /// 1. All logs in ExampleClass are printed (because level: Level.verbose)
  /// 2. Logs in IgnoredClass are not printed (because ignoreTypes: IgnoredClass),
  /// except for logs at level of warning and above (because ignoreLevel: Level.warning)

  ExampleClass.run();
  print('========================================');
  IgnoredClass.run();
  print('========================================');

  /// 3. Printed log for this will show ExampleClass.nestedRun() instead of
  /// syncTryCatchHandler (because ignoreCallers: {'syncTryCatchHandler'})
  ExampleClass.nestedRun();
}

class ExampleClass {
  static void run() {
    logger.log(Level.verbose, 'log: verbose');

    logger.v('verbose');
    logger.d('debug');
    logger.i('info');
    logger.w('warning');
    logger.e('error');
    logger.wtf('wtf');
  }

  static void nestedRun() {
    // nested functions will print
    syncTryCatchHandler(
      tryFunction: () => jsonDecode('thisIsNotJson'),
    );
  }
}

class IgnoredClass {
  static void run() {
    logger.v('verbose');
    logger.d('debug');
    logger.i('info');
    logger.w('warning');
    logger.e('error');
    logger.wtf('wtf');
  }
}

/// Synchronous try and catch handler to reduce boilerplate
///
/// Used as an example to show how nested functions can be ignored in [ignoreCallers]
dynamic syncTryCatchHandler(
    {dynamic Function()? tryFunction,
    Map<Exception, dynamic Function()?>? catchKnownExceptions,
    dynamic Function()? catchUnknownExceptions}) {
  try {
    try {
      return tryFunction?.call();
    } on Exception catch (e, s) {
      if (catchKnownExceptions == null) {
        rethrow;
      } else if (catchKnownExceptions.containsKey(e)) {
        logger.w('handling known exception', e, s);
        catchKnownExceptions[e]?.call();
      } else {
        rethrow;
      }
    }
  } catch (e, s) {
    logger.e('catchUnknown', e, s);
    catchUnknownExceptions?.call();
  }
}

```